### PR TITLE
Added AH query for finding TVM data on Solorigate affected software

### DIFF
--- a/Campaigns/c2-lookup-from-nonbrowser[Solorigate]..md
+++ b/Campaigns/c2-lookup-from-nonbrowser[Solorigate]..md
@@ -51,6 +51,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate SolarWinds processes launching command prompt with the echo command](launching-cmd-echo[Solorigate].md)
 * [Locate Solorigate receiving DNS response](c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/c2-lookup-response[Solorigate].md
+++ b/Campaigns/c2-lookup-response[Solorigate].md
@@ -47,6 +47,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate SolarWinds processes launching command prompt with the echo command](launching-cmd-echo[Solorigate].md)
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/known-affected-software-orion[Solorigate].md
+++ b/Campaigns/known-affected-software-orion[Solorigate].md
@@ -1,0 +1,47 @@
+# View data on software identified as affected by Solorigate
+
+This query was originally published in the threat analytics report, *Solorigate supply chain attack*.
+
+Microsoft detects the [2020 SolarWinds supply chain attack](https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/) implant and its other components as *Solorigate*. A threat actor silently added malicious code to legitimate software updates for Orion, which is IT monitoring software provided by SolarWinds. In this way, malicious dynamic link libraries (DLLs) were distributed to SolarWinds customers.
+
+The following query searches Threat and Vulnerability Management (TVM) data for Orion software known to be affected by Solorigate.
+
+More Solorigate-related queries can be found listed under the [See also](#see-also) section of this document.
+
+## Query
+
+```kusto
+DeviceTvmSoftwareInventoryVulnerabilities
+| where CveId == 'TVM-2020-0002'
+| project DeviceId, DeviceName, SoftwareVendor, SoftwareName, SoftwareVersion
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact | v |  |
+| Vulnerability |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+
+## See also
+
+* [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Campaigns/known-affected-software-orion[Solorigate].md
+++ b/Campaigns/known-affected-software-orion[Solorigate].md
@@ -40,6 +40,13 @@ This query can be used to detect the following attack techniques and tactics ([s
 
 ## See also
 
+* [Credentials were added to an Azure AD application after 'Admin Consent' permissions granted [Solorigate]](../Persistence/CredentialsAddAfterAdminConsentedToApp[Solorigate].md)
+* [Locate Solorigate-related malicious DLLs loaded in memory](locate-dll-loaded-in-memory[Solorigate].md)
+* [Locate Solorigate-related malicious DLLs created in the system or locally](locate-dll-created-locally[Solorigate].md)
+* [Locate SolarWinds processes launching suspicious PowerShell commands](launching-base64-powershell[Solorigate].md)
+* [Locate SolarWinds processes launching command prompt with the echo command](launching-cmd-echo[Solorigate].md)
+* [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](c2-lookup-from-nonbrowser[Solorigate]..md)
+* [Locate Solorigate receiving DNS response](c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
 
 ## Contributor info

--- a/Campaigns/launching-base64-powershell[Solorigate].md
+++ b/Campaigns/launching-base64-powershell[Solorigate].md
@@ -53,6 +53,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/launching-cmd-echo[Solorigate].md
+++ b/Campaigns/launching-cmd-echo[Solorigate].md
@@ -47,6 +47,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/locate-dll-created-locally[Solorigate].md
+++ b/Campaigns/locate-dll-created-locally[Solorigate].md
@@ -46,6 +46,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](../Campaigns/c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](../Campaigns/c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](../Campaigns/possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/locate-dll-loaded-in-memory[Solorigate].md
+++ b/Campaigns/locate-dll-loaded-in-memory[Solorigate].md
@@ -46,6 +46,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](../Campaigns/c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](../Campaigns/c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](../Campaigns/possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Campaigns/possible-affected-software-orion[Solorigate].md
+++ b/Campaigns/possible-affected-software-orion[Solorigate].md
@@ -49,6 +49,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate SolarWinds processes launching command prompt with the echo command](launching-cmd-echo[Solorigate].md)
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](c2-lookup-response[Solorigate].md)
+* [View data on software identified as affected by Solorigate](known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 

--- a/Persistence/CredentialsAddAfterAdminConsentedToApp[Solorigate].md
+++ b/Persistence/CredentialsAddAfterAdminConsentedToApp[Solorigate].md
@@ -57,6 +57,7 @@ This query can be used to detect the following attack techniques and tactics ([s
 * [Locate Solorigate attempting DNS lookup of command-and-control infrastructure](../Campaigns/c2-lookup-from-nonbrowser[Solorigate]..md)
 * [Locate Solorigate receiving DNS response](../Campaigns/c2-lookup-response[Solorigate].md)
 * [Get an inventory of SolarWinds Orion software possibly affected by Solorigate](../Campaigns/possible-affected-software-orion[Solorigate].md)
+* [View data on software identified as affected by Solorigate](../Campaigns/known-affected-software-orion[Solorigate].md)
 
 ## Contributor info
 **Contributor:** Tal Maor


### PR DESCRIPTION
Another query from the Solorigate TA. This is very similar to *Get an inventory of SolarWinds Orion software possibly affected by Solorigate* but is specific to tvm-2020-0002, not just Orion software in general.