### PR TITLE
Update insider-threat-detection-queries.md

### DIFF
--- a/General queries/insider-threat-detection-queries.md
+++ b/General queries/insider-threat-detection-queries.md
@@ -22,6 +22,7 @@ Note: no single indicator should be used as a lone determinant of insider threat
 DeviceLogonEvents
 | where IsLocalAdmin ==0
 | where InitiatingProcessAccountName != "system"
+
 // --------------------------------------------------------------------------------------------------------------------------- //
 //
 //Zip/Encrypt Sensitive File
@@ -63,6 +64,7 @@ DeviceProcessEvents
 | summarize count(AccountName) by AccountName
 | where count_AccountName > PRINT_THRESHOLD
 | sort by count_AccountName desc
+
 //Secondary Query
 //This eventtype exists, but seems to be a bit noisy
 DeviceEvents

--- a/General queries/insider-threat-detection-queries.md
+++ b/General queries/insider-threat-detection-queries.md
@@ -19,7 +19,7 @@ Note: no single indicator should be used as a lone determinant of insider threat
 //
 //Local Administrator
 //
-LogonEvents
+DeviceLogonEvents
 | where IsLocalAdmin ==0
 | where InitiatingProcessAccountName != "system"
 // --------------------------------------------------------------------------------------------------------------------------- //
@@ -59,7 +59,7 @@ union ProcessQuery, FileQuery
 //let PRINT_THRESHOLD = 3;  // adjust accordingly
 //-----
 DeviceProcessEvents 
-| where FileName in ("SnippingTool.exe", "ScreenSketch.exe") //and EventTime > ago(20d)
+| where FileName in ("SnippingTool.exe", "ScreenSketch.exe") //and Timestamp > ago(20d)
 | summarize count(AccountName) by AccountName
 | where count_AccountName > PRINT_THRESHOLD
 | sort by count_AccountName desc
@@ -83,7 +83,7 @@ and RemoteUrl has_any (webmailURLs)
 //Access after Termination
 //
 // Look for any activity by a terminated employee account creating a
-// NetworkCommunicationEvents after they were released
+// DeviceNetworkEvents after they were released
 let TermAccount = 'FORMER_EMPLOYEE_NAME';  // Could also use SID
 let ReleaseTime = datetime("M/D/Y H:M:S AM/PM");
 //


### PR DESCRIPTION
The query contains an old reference LogonEvents should be change with DeviceLogonEvents
The query contains an old reference EventTime should be change with Timestamp
The query contains an old reference NetworkCommunicationEvents should be change with DeviceNetworkEvents