### PR TITLE
Update PowerShell downloads.txt

### DIFF
--- a/Execution/PowerShell downloads.txt
+++ b/Execution/PowerShell downloads.txt
@@ -8,7 +8,6 @@ DeviceProcessEvents
    or ProcessCommandLine has "Invoke-Shellcode"
    or ProcessCommandLine has "http"
    or ProcessCommandLine has "IEX"
-   or ProcessCommandLine has "Net.WebClient"
    or ProcessCommandLine has "Start-BitsTransfer"
    or ProcessCommandLine has "mpcmdrun.exe"
 | project Timestamp, DeviceName, InitiatingProcessFileName, FileName, ProcessCommandLine

--- a/Execution/PowerShell downloads.txt
+++ b/Execution/PowerShell downloads.txt
@@ -8,7 +8,6 @@ DeviceProcessEvents
    or ProcessCommandLine has "Invoke-Shellcode"
    or ProcessCommandLine has "http"
    or ProcessCommandLine has "IEX"
-   or ProcessCommandLine has "System.Net.WebClient"
    or ProcessCommandLine has "Net.WebClient"
    or ProcessCommandLine has "Start-BitsTransfer"
    or ProcessCommandLine has "mpcmdrun.exe"


### PR DESCRIPTION
I assume we can remove 'System.Net.WebClient' since it will be already returned in 'Net.WebClient', because both CONTAIN 'Net.WebClient'. This might not be true to MSDFE querying tho, as it might get confused due to 'dots'.