### PR TITLE
queries related to snip3 RATs

### DIFF
--- a/Campaigns/aviation-targeting-emails-snip3.md
+++ b/Campaigns/aviation-targeting-emails-snip3.md
@@ -1,0 +1,48 @@
+# Detect malicious use of RegAsm, RegSvcs, and InstallUtil by Snip3
+
+Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
+
+The following query looks for keywords observed in emails involved in a Snip3-associated campaign in April and May of 2021. The emails often have an aviation theme, and the campaign primarily targets organizations involved in travel or  aviation. Note that keywords may change overtime. These emails were used to send malicious legitimate hosting provider links that redirected to VBS documents hosting loaders. The loaders initiate RevengeRAT or AsyncRAT downloads that eventually establish persistence on targets and exfiltrate data.
+
+## Query
+
+```kusto
+let SubjectTerms = 
+pack_array("Cargo Charter","Airbus Meeting","WorldWide Symposium","Airbus Family","Flight Request",
+"Advice from NetJets","May/ACMI","AIRCRAFT PRESENTATION","Airworthiness", "Air Quote", "RFQ #9B17811");
+EmailEvents
+| where SenderDisplayName has_any(SubjectTerms)
+// Optional Sender restriction for organizations with high FP
+// where SenderIpv4 == "192.145.239.18"  
+| where EmailDirection == "Inbound"  
+| join EmailUrlInfo on $left.NetworkMessageId == $right.NetworkMessageId
+| where Url has_any("drive.google.com","1drv.ms","onedrive.live.com")
+| take 100
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access | v |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Exploit |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+| Ransomware |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Campaigns/aviation-targeting-emails-snip3.md
+++ b/Campaigns/aviation-targeting-emails-snip3.md
@@ -1,4 +1,4 @@
-# Detect malicious use of RegAsm, RegSvcs, and InstallUtil by Snip3
+# Detect keywords associated with Snip3 campaign emails
 
 Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
 

--- a/Campaigns/detectsanboxie-function-call-snip3.md
+++ b/Campaigns/detectsanboxie-function-call-snip3.md
@@ -2,7 +2,7 @@
 
 Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
 
-The following query looks for a function call to a method named *DetectSandboxie*. This method is only used in RevengeRAT and AsyncRAT instances involved in a campaign targeting the aviation industry, first observed in 2021. Individual PowerShell functions can be detected in the same way in some instances, though care should be taken to ensure that the command name is unique -- otherwise, this query may return many false positives.
+The following query looks for a function call to a method named *DetectSandboxie*. This method is used in RevengeRAT and AsyncRAT instances involved in a campaign targeting the aviation industry, first observed in 2021. It has also been associated in the past other malware, such as WannaCry. Individual PowerShell functions can be detected in the same way in some instances, though care should be taken to ensure that the command name is unique -- otherwise, this query may return many false positives.
 
 ## Query
 

--- a/Campaigns/detectsanboxie-function-call-snip3.md
+++ b/Campaigns/detectsanboxie-function-call-snip3.md
@@ -2,7 +2,7 @@
 
 Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
 
-The following query looks for a function call to a method named *DetectSandboxie*. This method is used in RevengeRAT and AsyncRAT instances involved in a campaign targeting the aviation industry, first observed in 2021. It has also been associated in the past other malware, such as WannaCry. Individual PowerShell functions can be detected in the same way in some instances, though care should be taken to ensure that the command name is unique -- otherwise, this query may return many false positives.
+The following query looks for a function call to a method named *DetectSandboxie*. This method is used in RevengeRAT and AsyncRAT instances involved in a campaign targeting the aviation industry, first observed in 2021. It has also been associated in the past other malware, such as WannaCry and QuasarRAT. Individual PowerShell functions can be detected in the same way in some instances, though care should be taken to ensure that the command name is unique -- otherwise, this query may return many false positives.
 
 ## Query
 

--- a/Campaigns/detectsanboxie-function-call-snip3.md
+++ b/Campaigns/detectsanboxie-function-call-snip3.md
@@ -1,0 +1,40 @@
+# Detect Snip3 loader call to DetectSandboxie function
+
+Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
+
+The following query looks for a function call to a method named *DetectSandboxie*. This method is only used in RevengeRAT and AsyncRAT instances involved in a campaign targeting the aviation industry, first observed in 2021. Individual PowerShell functions can be detected in the same way in some instances, though care should be taken to ensure that the command name is unique -- otherwise, this query may return many false positives.
+
+## Query
+
+```kusto
+DeviceEvents
+| where ActionType == "PowerShellCommand" 
+| where AdditionalFields == "{\"Command\":\"DetectSandboxie\"}"
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution | v |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion | v |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Exploit |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+| Ransomware |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Campaigns/encoded-powershell-structure-snip3.md
+++ b/Campaigns/encoded-powershell-structure-snip3.md
@@ -1,0 +1,43 @@
+# Detect Snip3 loader-encoded PowerShell command
+
+Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
+
+The following query looks for the method that Snip3 malware use to obfuscate PowerShell commands with UTF8 encoding. This technique is intended to evade detection from security products, and avoids the more standard switches used for encoding in malware such as Emotet.
+
+At present, this method of encoding is much more rare, being seen largely with loader installation of RevengeRAT, AsyncRAT and other RATs used in campaigns targeting the aviation industry.
+
+## Query
+
+```kusto
+DeviceProcessEvents 
+| where InitiatingProcessFileName == "powershell.exe" 
+| where InitiatingProcessCommandLine has_all  
+("powershell.exe","-WINDOWSTYLE HIDDEN","-EXECUTIONPOLICY UNRESTRICTED","-COMMAND IEX","System.Text.Encoding","::UTF8.GetString") 
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion | v |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Exploit |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+| Ransomware |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Campaigns/malicious-network-connectivity-snip3.md
+++ b/Campaigns/malicious-network-connectivity-snip3.md
@@ -1,0 +1,43 @@
+# Detect malicious use of RegAsm, RegSvcs, and InstallUtil by Snip3
+
+Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
+
+The following query looks for potentially hollowed processes that may be used to facilitate command-and-control or exfiltration by Snip3 malware. This technique has been used in recent cases to exfiltrate data, including credentials. 
+
+The query may return additional malware or campaigns not necessarily associated with Snip3. However, Microsoft recommends triaging all non-benign results as potential malware.
+
+## Query
+
+```kusto
+DeviceNetworkEvents 
+| where InitiatingProcessFileName in ("RevSvcs.exe","RegAsm.exe", "InstallUtil.exe") 
+| where InitiatingProcessCommandLine in ("\"RegAsm.exe\"","\"RevSvcs.exe\"","\"InstallUtil.exe\"") 
+| where InitiatingProcessParentFileName endswith "Powershell.exe"
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control | v |  |
+| Exfiltration | v |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Exploit |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+| Ransomware |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Campaigns/revengerat-c2-exfiltration-snip3.md
+++ b/Campaigns/revengerat-c2-exfiltration-snip3.md
@@ -1,0 +1,41 @@
+# Detect Snip3 associated communication protocols
+
+Snip3 is a family of related remote access trojans. Although the malware in this family contain numerous small variations, they all exhibit similar behaviors and techniques.
+
+The following query looks for network connections using any protocols associated with recent RevengeRAT, AsyncRAT, and other malware campaigns targeting the aviation industry.
+
+This activity is often followed by connections to copy-and-paste sites such as pastebin.com, stikked.ch, academia.edu, and archive.org. Many of these connections will occur on non-standard ports.
+
+## Query
+
+```kusto
+DeviceNetworkEvents 
+| where RemoteUrl in ("mail.alamdarhardware.com","kexa600200.ddns.net","h0pe1759.ddns.net","n0ahark2021.ddns.net"," kimjoy007.dyndns.org"," kimjoy.ddns.net"," asin8988.ddns.net"," asin8989.ddns.net", "asin8990.ddns.net")
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control | v |  |
+| Exfiltration | v |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Exploit |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+| Ransomware |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team


### PR DESCRIPTION
We have a report in the works describing a campaign using numerous, similar RATs, all classed together under the Snip3 name. 

These queries are going out ahead of the report to keep customers protected. 